### PR TITLE
Feature/esafe 298 add rsa signing to cryppo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meeco/cryppo",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "In-browser encryption and decryption. Clone of Ruby Cryppo",
   "scripts": {
     "browser": "karma start",

--- a/src/signing/rsa-signature.ts
+++ b/src/signing/rsa-signature.ts
@@ -1,0 +1,47 @@
+import { pki, md } from 'node-forge';
+import { encodeSafe64, decodeSafe64 } from '../../src/util';
+
+
+export interface ISignature {
+    signature: string;
+    data: string;
+}
+
+export function signWithPrivateKey(privateKeyPem: string, data: string): ISignature {
+    const mdDigest = md.sha256.create();
+    const key = pki.privateKeyFromPem(privateKeyPem) as pki.rsa.PrivateKey;
+    mdDigest.update(data, 'utf8');
+    const signature = key.sign(mdDigest);
+    return {
+        signature: signature,
+        data: data
+    };
+}
+
+export function serializeRsaSignature(signatureObj: ISignature): string{
+    return `Sign.Rsa4096.${encodeSafe64(signatureObj.signature)}.${encodeSafe64(signatureObj.data)}`;
+}
+
+export function loadRsaSignature(serializedPayload: string): ISignature{
+    const decomposedPayload = serializedPayload.split('.')
+    const signed = decomposedPayload[0]
+    const signingStrategy = decomposedPayload[1]
+    const encodedSignature = decomposedPayload[2]
+    const encodedData = decomposedPayload[3]
+
+    if(signed == "Sign" && signingStrategy == "Rsa4096"){
+        return {
+            signature: decodeSafe64(encodedSignature),
+            data: decodeSafe64(encodedData)
+        };
+    }else{
+        throw new Error("String is not a serialized RSA signature");
+    }
+}
+
+export function verifyWithPublicKey(publicKeyPem: string, signatureObj: ISignature){
+    const key = pki.publicKeyFromPem(publicKeyPem) as pki.rsa.PublicKey;
+    const mdDigest = md.sha256.create();
+    mdDigest.update(signatureObj.data, 'utf8');
+    return key.verify(mdDigest.digest().bytes(), signatureObj.signature)
+}

--- a/test/signing/rsa-signature.spec.ts
+++ b/test/signing/rsa-signature.spec.ts
@@ -1,0 +1,32 @@
+import { signWithPrivateKey, verifyWithPublicKey, serializeRsaSignature, loadRsaSignature } from '../../src/signing/rsa-signature';
+import { generateRSAKeyPair } from '../../src/key-pairs/rsa';
+import { encodeSafe64 } from '../../src/util';
+
+describe('signing', () => {
+  const data = 'Sign me!';
+  it('can sign a message with a private key then serialize it', async done => {
+      try {
+        const keyPair = await generateRSAKeyPair();
+        const signatureObj = signWithPrivateKey(keyPair.privateKey, data);
+        const serializedPayload = serializeRsaSignature(signatureObj);
+        expect(serializedPayload.split('.')[3]).toEqual(encodeSafe64(data));
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+  it('can load a signature then verify it', async done => {
+    try {
+      const keyPair = await generateRSAKeyPair();
+      const signatureObj = signWithPrivateKey(keyPair.privateKey, data);
+      const serializedPayload = serializeRsaSignature(signatureObj);
+      const loadedSignature = loadRsaSignature(serializedPayload);
+      expect(verifyWithPublicKey(keyPair.publicKey, loadedSignature)).toEqual(true);
+      done();
+    } catch (err) {
+      done(err);
+    }
+  });
+
+});
+  


### PR DESCRIPTION
This is intended to mirror changes to the Ruby Cryppo gem, providing a facility to sign and verify messages with an RSA keypair, as well as serialize a signature and corresponding data for transport to the keystore microservice.