### PR TITLE
Expose methods of converting to and from a Buffer in public API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,15 +5,16 @@ export * from './encryption/encryption';
 export * from './key-derivation/derived-key';
 export * from './key-derivation/pbkdf2-hmac';
 export * from './key-pairs/rsa';
-export * from './strategies';
 export * from './signing/rsa-signature';
-
+export * from './strategies';
 export {
+  binaryBufferToString,
   decodeDerivationArtifacts,
+  decodeSafe64,
+  deSerializeDerivedKeyOptions,
   encodeDerivationArtifacts,
+  encodeSafe64,
   generateEncryptionVerificationArtifacts,
   generateRandomKey,
-  encodeSafe64,
-  decodeSafe64,
-  deSerializeDerivedKeyOptions
+  stringAsBinaryBuffer,
 } from './util';

--- a/src/util.ts
+++ b/src/util.ts
@@ -35,7 +35,7 @@ export function deSerializeDerivedKeyOptions(
   const serializationArtifacts = decodeArtifactData(yamlArtifacts);
   return {
     derivationStrategy,
-    serializationArtifacts
+    serializationArtifacts,
   };
 }
 
@@ -91,7 +91,7 @@ export function deSerialize(serialized: string): IDecoded {
 
   return {
     encryptionStrategy,
-    decodedPairs
+    decodedPairs,
   };
 }
 
@@ -99,7 +99,7 @@ function decodeArtifactData(text: string) {
   return YAML.parse(text.replace(/ !binary/g, ' !!binary'));
 }
 
-export function stringAsBinaryBuffer(val: string): Uint8Array {
+export function stringAsBinaryBuffer(val: string): Buffer | Uint8Array {
   if (typeof Buffer !== 'undefined') {
     return Buffer.from(val, 'binary');
   }
@@ -111,7 +111,7 @@ export function stringAsBinaryBuffer(val: string): Uint8Array {
   return bufView;
 }
 
-export function binaryBufferToString(val: any): string {
+export function binaryBufferToString(val: Buffer | Uint8Array | ArrayBuffer): string {
   return util.createBuffer(val).data;
 }
 
@@ -154,7 +154,7 @@ export function generateEncryptionVerificationArtifacts() {
   const salt = random.getBytesSync(16);
   return {
     token: encodeSafe64(token),
-    salt: encodeSafe64(salt)
+    salt: encodeSafe64(salt),
   };
 }
 


### PR DESCRIPTION
Lots of other codebases end up using these methods and they end up getting imported out of 
`'@meeco/cryppo/dist/src/uti'` which isn't ideal.

Might as well expose them as part of the public API.