### PR TITLE
Remove use of global buffer and add global polyfills

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4040,14 +4040,12 @@
       }
     },
     "buffer": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-      "dev": true,
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
       "requires": {
         "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-alloc": {
@@ -10739,6 +10737,17 @@
         "vm-browserify": "^1.0.1"
       },
       "dependencies": {
+        "buffer": {
+          "version": "4.9.2",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meeco/cryppo",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "0.7.0",
   "description": "In-browser encryption and decryption. Clone of Ruby Cryppo",
   "engines": {
     "node": ">=12.4.0"
@@ -43,6 +43,7 @@
   "license": "MIT",
   "dependencies": {
     "bson": "^4.0.4",
+    "buffer": "^5.1.0",
     "node-forge": "0.8.5",
     "yaml": "^1.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meeco/cryppo",
-  "version": "0.7.0",
+  "version": "0.0.0-PLACEHOLDER",
   "description": "In-browser encryption and decryption. Clone of Ruby Cryppo",
   "engines": {
     "node": ">=12.4.0"
@@ -43,7 +43,7 @@
   "license": "MIT",
   "dependencies": {
     "bson": "^4.0.4",
-    "buffer": "^5.1.0",
+    "buffer": "^5..0",
     "node-forge": "0.8.5",
     "yaml": "^1.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "license": "MIT",
   "dependencies": {
     "bson": "^4.0.4",
-    "buffer": "^5..0",
+    "buffer": "^5.1.0",
     "node-forge": "0.8.5",
     "yaml": "^1.6.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,9 @@
-// import { encryptWithDerivedKey } from './encrypt-with-derived-key';
+import { Buffer as _buffer } from 'buffer';
+if (typeof window !== 'undefined' && typeof (<any>window).global === 'undefined') {
+  // Ensures browser will run without manual polyfills in Angular
+  (<any>window).Buffer = _buffer;
+  (<any>window).global = window;
+}
 
 export * from './decryption/decryption';
 export * from './encryption/encryption';

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,5 @@
 import * as BSON from 'bson';
+import { Buffer as _buffer } from 'buffer';
 import { pki, random, util } from 'node-forge';
 import * as YAML from 'yaml';
 import { IEncryptionArtifacts } from './encryption/encryption';
@@ -126,20 +127,13 @@ function decodeArtifactData(text: string) {
   } else {
     text = decodeSafe64Bson(text);
     // remove version byte before deserializing
-    return BSON.deserialize(Buffer.from(text, 'base64').slice(1), { promoteBuffers: true });
+    return BSON.deserialize(_buffer.from(text, 'base64').slice(1), { promoteBuffers: true });
   }
 }
 
 export function stringAsBinaryBuffer(val: string): Buffer | Uint8Array {
-  if (typeof Buffer !== 'undefined') {
-    return Buffer.from(val, 'binary');
-  }
-
-  const bufView = new Uint8Array(val.length);
-  for (let i = 0, strLen = val.length; i < strLen; i++) {
-    bufView[i] = val.charCodeAt(i);
-  }
-  return bufView;
+  // We use the polyfill for browser coverage and compatibility with bson serialize
+  return _buffer.from(val, 'binary');
 }
 
 export function binaryBufferToString(val: Buffer | Uint8Array | ArrayBuffer): string {
@@ -174,7 +168,7 @@ export function encodeSafe64Bson(
   versionByte: string,
   artifacts: IDerivedKey | IEncryptionArtifacts | ICryppoSerializationArtifacts
 ) {
-  const bsonSerialized = Buffer.concat([Buffer.from(versionByte), BSON.serialize(artifacts)]);
+  const bsonSerialized = _buffer.concat([_buffer.from(versionByte), BSON.serialize(artifacts)]);
   const base64Data = bsonSerialized.toString('base64');
   return base64Data
     .replace(/\+/g, '-') // Convert '+' to '-'


### PR DESCRIPTION
1. `Buffer` does not exist in the browser - so `Buffer.from` etc would crash. Have replaced with the `buffer` polyfill that is used by BSON under the hood
2. [`bson` requires `global` to be defined](https://github.com/mongodb/js-bson/issues/301). Rather than expecting users of cryppo to manually add this polyfill patch - we now provide it out of the box (have tested with an Angular 10 project).